### PR TITLE
Replace dotenv requirement with python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dotenv
+python-dotenv
 groq
 termcolor


### PR DESCRIPTION
Hi,

Please see this error and the solution + explanation:

https://stackoverflow.com/questions/76301261/dotenv-install-error-error-invalid-command-dist-info

Thank you.